### PR TITLE
fix(corepack): Manually install newer version of corepack to avoid key id mismatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - run: npm install -g corepack@v0.31.0
       - run: corepack enable
       - run: pnpm install
       - run: pnpm prettier

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,10 @@ RUN install-tool docker v27.5.1
 # renovate: datasource=github-releases packageName=containerbase/node-prebuild versioning=node
 RUN install-tool node 20.18.2
 
+# temporary: install corepack via npm until upgrading to a newer version of node where
+# https://github.com/nodejs/corepack/issues/612#issuecomment-2616588603
+RUN npm install -g corepack@v0.31.0
+
 # enable buildin corepack
 RUN corepack enable
 


### PR DESCRIPTION
https://github.com/nodejs/corepack/issues/612#issuecomment-2616588603

This temporary fix is required to get corepack working again until the next release of node